### PR TITLE
Test

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -3069,7 +3069,7 @@ void item::on_contents_changed()
                     charges = it.charges;
                 }
             }
-        } else if( ammo_data()->phase == LIQUID ) {
+        } else if( ammo_data() && ammo_data()->phase == LIQUID ) {
             charges = 0;
         }
     }


### PR DESCRIPTION
Summary
SUMMARY: Bugfixes "Fix crash related to null pointer error in 'src/item.cpp' on on_contents_changed function"

Purpose of change
Avoid null pointer error in advance by the check.

Describe the solution
ammo_data() function sometimes return nullptr(ex. cash_card of empty contents field).
It causes crash by nullptr error. Avoid null pointer error in advance by the check.